### PR TITLE
hover evaluate on selection

### DIFF
--- a/modules/dap/configuration.py
+++ b/modules/dap/configuration.py
@@ -36,6 +36,11 @@ class AdapterConfiguration:
 	async def installed_status(self, log: core.Logger) -> str | None: ...
 
 	def on_hover_provider(self, view: sublime.View, point: int) -> tuple[str, sublime.Region] | None:
+		for region in view.sel():
+			if region.begin() <= point <= region.end():
+				word = region
+				word_string = view.substr(word)
+				return (word_string, word)
 		word = view.word(point)
 		if word_string := view.substr(word) if word else None:
 			return (word_string, word)


### PR DESCRIPTION
Hover currently only evaluates on a word boundary, so if you hover over 'self.name' it will only be able to evaluate 'self' or 'name', where 'name' will obviously fail.
on_hover_provider now checks if the mouse is hovered over a selected region and pass that region for evaluation, if not, will default to the normal hover evaluation on word boundary.

This allows for evaluating expressions rather than just simple variable names, eg: 'self.name[3:5]+"suffix"'.

any errors in evaluation due to incomplete selections will just print "Debugger: error: adapter failed hover evaluation Exception occurred during evaluation." same as it would with the default behaviour if you hovered over 'name'